### PR TITLE
snapd.bb: add "libcap" to DEPENDS

### DIFF
--- a/recipes-support/snapd/snapd_2.56.2.bb
+++ b/recipes-support/snapd/snapd_2.56.2.bb
@@ -20,6 +20,7 @@ DEPENDS += "			\
 	glib-2.0		\
 	udev			\
 	xfsprogs		\
+	libcap			\
 	libseccomp      \
 	${@bb.utils.contains('DISTRO_FEATURES', 'apparmor', 'apparmor', '', d)}	\
 "


### PR DESCRIPTION
Otherwise:

  | bootstrap.c:37:10: fatal error: sys/capability.h: No such file or directory
  |    37 | #include <sys/capability.h>
  |       |          ^~~~~~~~~~~~~~~~~~
  | compilation terminated.

Signed-off-by: Robert P. J. Day <robert.day@canonical.com>