### PR TITLE
snapd: drop duplicated apparmor in depends

### DIFF
--- a/recipes-support/snapd/snapd.inc
+++ b/recipes-support/snapd/snapd.inc
@@ -14,7 +14,6 @@ PACKAGECONFIG[apparmor] = "--enable-apparmor,--disable-apparmor,apparmor,apparmo
 GO_IMPORT = "github.com/snapcore/snapd"
 
 DEPENDS += " \
-	${@bb.utils.contains('DISTRO_FEATURES', 'apparmor', 'apparmor', '', d)}	\
 	glib-2.0		\
 	libcap			\
 	libseccomp		\


### PR DESCRIPTION
This is already automatically added through PKGCONFIG[apparmor].

