### PR TITLE
distro/snapd_on_yp.conf: define new DISTRO of "snapd_on_yp"

### DIFF
--- a/conf/distro/snapd_on_yp.conf
+++ b/conf/distro/snapd_on_yp.conf
@@ -1,0 +1,27 @@
+#####################################################
+#
+#  To take advantage of this conf file, add the line
+#
+#  DISTRO = "snapd_on_yp"
+#
+#  to your local.conf file.
+#
+#####################################################
+
+# Select systemd as the init manager (required).
+INIT_MANAGER = "systemd"
+
+# Build the final image from .deb packages.
+PACKAGE_CLASSES = "package_deb"
+
+# If you want on-board package management, uncomment this line.
+# IMAGE_FEATURES:append = " package-management"
+
+# Add the essential DISTRO_FEATURES.
+DISTRO_FEATURES:append = " \
+	apparmor \
+	security \
+"
+
+# snapd really wants root's home dir at /root, not /home/root.
+ROOT_HOME = "/root"


### PR DESCRIPTION
Centralize snapd-related settings in a single new DISTRO file
you can invoke from local.conf:

  * INIT_MANAGER = "systemd"
  * PACKAGE_CLASSES = "package_deb"
  * DISTRO_FEATURES:append = " \
        apparmor \
        security \
    "
  * ROOT_HOME = "/root"

Signed-off-by: Robert P. J. Day <robert.day@canonical.com>