### PR TITLE
snapd_2.56.3.bb: add recipe for newest snapd, but make non-default

### DIFF
--- a/recipes-support/snapd/snapd_2.56.3.bb
+++ b/recipes-support/snapd/snapd_2.56.3.bb
@@ -1,0 +1,5 @@
+include snapd.inc
+DEFAULT_PREFERENCE = "-1"
+
+SRC_URI[md5sum] = "7c2b0900dbfed98747c283a068a80b0f"
+SRC_URI[sha256sum] = "302747ed9e854af1740ee6660be7a17fd36fb4de0e1dedf42a4020b78c6c06fa"


### PR DESCRIPTION
Allow developers to select snapd_2.56.3 in their local.conf with:

PREFERRED_VERSION_snapd = "2.56.3"

At some point, when everyone is happy, make this the default.

Signed-off-by: Robert P. J. Day <robert.day@canonical.com>