### PR TITLE
snapd-native: fix build with go 1.18+

### DIFF
--- a/recipes-support/snapd/snapd-native_2.56.2.bb
+++ b/recipes-support/snapd/snapd-native_2.56.2.bb
@@ -43,7 +43,10 @@ do_configure() {
 
 do_compile() {
 	# only build the snap tool
-	${GO} install -tags 'nosecboot nomanagers' ${GOBUILDFLAGS} github.com/snapcore/snapd/cmd/snap
+	(
+		cd ${S}
+		${GO} install -tags '${GO_BUILD_TAGS}' -mod=vendor ${GOBUILDFLAGS} github.com/snapcore/snapd/cmd/snap
+	)
 }
 
 do_install() {


### PR DESCRIPTION
When calling go install out of the source tree of the package which is a module, Go insists on
passing the version after a '@'. Then the build fails like so:

```
| DEBUG: Executing shell function do_compile
| go install: version is required when current directory is not in a module
|       Try 'go install github.com/snapcore/snapd/cmd/snap@latest' to install the latest version
| WARNING: <snip>/yocto/kirkstone-snapd/tmp/work/x86_64-linux/snapd-native/2.56.2-r0/temp/run.do_compile.2824723:167 exit 1 from 'go install -tags 'nosecboot nomanagers' -p 16 -v -ldflags=" --linkmode=external  -extldflags '  -L<snip>/yocto/kirkstone-snapd/tmp/work/x86_64-linux/snapd-native/2.56.2-r0/recipe-sysroot-nat'
| WARNING: Backtrace (BB generated script):
|       #1: do_compile, <snip>/yocto/kirkstone-snapd/tmp/work/x86_64-linux/snapd-native/2.56.2-r0/temp/run.do_compile.2824723, line 167
|       #2: main, <snip>/yocto/kirkstone-snapd/tmp/work/x86_64-linux/snapd-native/2.56.2-r0/temp/run.do_compile.2824723, line 171
ERROR: Task (<snip>/yocto/meta-snapd/recipes-support/snapd/snapd-native_2.56.2.bb:do_compile) failed with exit code '1'
NOTE: Tasks Summary: Attempted 3203 tasks of which 3195 didn't need to be rerun and 1 failed.
```
