### PR TITLE
linux: split out patches to separate include file

### DIFF
--- a/recipes-kernel/linux/linux-snapd.inc
+++ b/recipes-kernel/linux/linux-snapd.inc
@@ -1,0 +1,12 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+# patches cherry-picked from Ubuntu's kernel source code at:
+# https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/focal/log/security/apparmor?h=hwe-5.11
+
+SRC_URI += "file://snaps.cfg \
+            file://0001-UBUNTU-SAUCE-apparmor-af_unix-mediation.patch \
+            file://0002-UBUNTU-SAUCE-apparmor-patch-to-provide-compatibility.patch \
+            file://0003-UBUNTU-SAUCE-apparmor-fix-use-after-free-in-sk_peer_.patch \
+            file://0004-UBUNTU-SAUCE-apparmor-fix-apparmor-mediating-locking.patch \
+            file://0005-UBUNTU-SAUCE-apparmor-rename-kzfree-to-kfree_sensiti.patch \
+            "

--- a/recipes-kernel/linux/linux-yocto_5.10.bbappend
+++ b/recipes-kernel/linux/linux-yocto_5.10.bbappend
@@ -1,12 +1,1 @@
-FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
-
-# patches cherry-picked from Ubuntu's kernel source code at:
-# https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/focal/log/security/apparmor?h=hwe-5.11
-
-SRC_URI += "file://snaps.cfg \
-            file://0001-UBUNTU-SAUCE-apparmor-af_unix-mediation.patch \
-            file://0002-UBUNTU-SAUCE-apparmor-patch-to-provide-compatibility.patch \
-            file://0003-UBUNTU-SAUCE-apparmor-fix-use-after-free-in-sk_peer_.patch \
-            file://0004-UBUNTU-SAUCE-apparmor-fix-apparmor-mediating-locking.patch \
-            file://0005-UBUNTU-SAUCE-apparmor-rename-kzfree-to-kfree_sensiti.patch \
-            "
+require recipes-kernel/linux/linux-snapd.inc

--- a/recipes-kernel/linux/linux-yocto_5.15.bbappend
+++ b/recipes-kernel/linux/linux-yocto_5.15.bbappend
@@ -1,12 +1,1 @@
-FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
-
-# patches cherry-picked from Ubuntu's kernel source code at:
-# https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/focal/log/security/apparmor?h=hwe-5.11
-
-SRC_URI += "file://snaps.cfg \
-            file://0001-UBUNTU-SAUCE-apparmor-af_unix-mediation.patch \
-            file://0002-UBUNTU-SAUCE-apparmor-patch-to-provide-compatibility.patch \
-            file://0003-UBUNTU-SAUCE-apparmor-fix-use-after-free-in-sk_peer_.patch \
-            file://0004-UBUNTU-SAUCE-apparmor-fix-apparmor-mediating-locking.patch \
-            file://0005-UBUNTU-SAUCE-apparmor-rename-kzfree-to-kfree_sensiti.patch \
-            "
+require recipes-kernel/linux/linux-snapd.inc


### PR DESCRIPTION
Since patches should apply cleanly on most kernels, split out their application into a separate include file which can be 'required' by consumers of this layer.