### PR TITLE
snapd: move to go-mod, use common include for go setup

### DIFF
--- a/recipes-support/snapd/snapd-go.inc
+++ b/recipes-support/snapd/snapd-go.inc
@@ -1,0 +1,64 @@
+inherit go-mod
+
+GO_IMPORT = "github.com/snapcore/snapd"
+
+# disable shared runtime for x86
+# https://forum.snapcraft.io/t/yocto-rocko-core-snap-panic/3261
+# GO_DYNLINK is set with arch overrides in goarch.bbclass
+GO_DYNLINK:x86 = ""
+GO_DYNLINK:x86-64 = ""
+GO_DYNLINK:arm = ""
+GO_DYNLINK:aarch64 = ""
+# modules are vendored in the release tarball
+GOBUILDFLAGS:append = " -mod=vendor"
+
+GO_BUILD_TAGS_snapd = "nosecboot"
+GO_BUILD_TAGS = "nosecboot nomanagers"
+
+# The go class does export a do_configure function, of which we need
+# to change the symlink set-up, to target snapd's environment.
+snapd_go_do_configure() {
+	mkdir -p ${S}/src/github.com/snapcore
+	ln -snf ${S} ${S}/src/${GO_IMPORT}
+	go_do_configure
+	# internally calls go run to generate some assets
+	(cd ${S} ; GOARCH=${GOHOSTARCH} sh -x ./mkversion.sh ${PV})
+}
+
+snapd_go_do_compile() {
+	(
+		cd ${S}
+		${GO} install -tags '${GO_BUILD_TAGS_snapd}' ${GOBUILDFLAGS} github.com/snapcore/snapd/cmd/snapd
+		${GO} install -tags '${GO_BUILD_TAGS}' ${GOBUILDFLAGS} github.com/snapcore/snapd/cmd/snap
+		${GO} install -tags '${GO_BUILD_TAGS}' ${GOBUILDFLAGS} github.com/snapcore/snapd/cmd/snap-seccomp
+		${GO} install -tags '${GO_BUILD_TAGS}' ${GOBUILDFLAGS} github.com/snapcore/snapd/cmd/snap-failure
+
+		# these *must* be built statically
+		for prog in snap-exec snap-update-ns snapctl; do
+			${GO} install -tags '${GO_BUILD_TAGS}' -mod=vendor -v \
+			      -ldflags="${GO_RPATH} -linkmode=external -extldflags '${HOST_CC_ARCH}${TOOLCHAIN_OPTIONS} ${GO_RPATH_LINK} ${LDFLAGS} -static'" \
+			      -trimpath \
+			      -mod=vendor \
+			      github.com/snapcore/snapd/cmd/$prog
+		done
+	)
+}
+
+snapd_go_install() {
+	install -m 0755 ${B}/${GO_BUILD_BINDIR}/snapd ${D}${libdir}/snapd/
+	install -m 0755 ${B}/${GO_BUILD_BINDIR}/snap-exec ${D}${libdir}/snapd/
+	install -m 0755 ${B}/${GO_BUILD_BINDIR}/snap-seccomp ${D}${libdir}/snapd/
+	install -m 0755 ${B}/${GO_BUILD_BINDIR}/snap-update-ns ${D}${libdir}/snapd/
+	install -m 0755 ${B}/${GO_BUILD_BINDIR}/snapctl ${D}${libdir}/snapd/
+	install -m 0755 ${B}/${GO_BUILD_BINDIR}/snap-failure ${D}${libdir}/snapd/
+	install -m 0755 ${B}/${GO_BUILD_BINDIR}/snap ${D}${bindir}
+	ln -s ${libdir}/snapd/snapctl ${D}${bindir}/snapctl
+}
+
+snapd_go_do_compile_snap() {
+	# only build the snap tool
+	(
+		cd ${S}
+		${GO} install -tags '${GO_BUILD_TAGS}' ${GOBUILDFLAGS} github.com/snapcore/snapd/cmd/snap
+	)
+}

--- a/recipes-support/snapd/snapd-go.inc
+++ b/recipes-support/snapd/snapd-go.inc
@@ -12,8 +12,14 @@ GO_DYNLINK:aarch64 = ""
 # modules are vendored in the release tarball
 GOBUILDFLAGS:append = " -mod=vendor"
 
+# tags to disable unnecessary functionality:
+# nosecboot  - disable secboot support, only useful for Ubuntu Core
+# nomanagers - disable the managers code which could have been be imported but
+#              isn't useful in binaries that aren't actual snapd daemon binary
 GO_BUILD_TAGS_snapd = "nosecboot"
 GO_BUILD_TAGS = "nosecboot nomanagers"
+# GO_BUILD_TAGS is expanded by bitbake, but must be a single string when passed
+# to go build -tags, hence it's single quoted where needed
 
 # The go class does export a do_configure function, of which we need
 # to change the symlink set-up, to target snapd's environment.

--- a/recipes-support/snapd/snapd-native_2.56.2.bb
+++ b/recipes-support/snapd/snapd-native_2.56.2.bb
@@ -12,8 +12,6 @@ SRC_URI = "									\
 SRC_URI[md5sum] = "5952bd537b14f74aa2c33ecba84e9d9a"
 SRC_URI[sha256sum] = "ee4096ef1a74a8d29b4cb7f43d442244beec413c21a517f34476270eb6a59fed"
 
-GO_IMPORT = "github.com/snapcore/snapd"
-
 RDEPENDS_${PN} += "		\
 	ca-certificates		\
 	bash \
@@ -21,32 +19,16 @@ RDEPENDS_${PN} += "		\
 
 S = "${WORKDIR}/snapd-${PV}"
 
-inherit go native
+require snapd-go.inc
 
-# disable shared runtime for x86
-# https://forum.snapcraft.io/t/yocto-rocko-core-snap-panic/3261
-# GO_DYNLINK is set with arch overrides in goarch.bbclass
-GO_DYNLINK:x86 = ""
-GO_DYNLINK:x86-64 = ""
-GO_DYNLINK:arm = ""
-GO_DYNLINK:aarch64 = ""
+inherit native
 
-# The go class does export a do_configure function, of which we need
-# to change the symlink set-up, to target snapd's environment.
 do_configure() {
-	mkdir -p ${S}/src/github.com/snapcore
-	ln -snf ${S} ${S}/src/${GO_IMPORT}
-	go_do_configure
-	# internally calls go run to generate some assets
-	(cd ${S} ; GOARCH=${GOHOSTARCH} sh -x ./mkversion.sh ${PV})
+	snapd_go_do_configure
 }
 
 do_compile() {
-	# only build the snap tool
-	(
-		cd ${S}
-		${GO} install -tags '${GO_BUILD_TAGS}' -mod=vendor ${GOBUILDFLAGS} github.com/snapcore/snapd/cmd/snap
-	)
+	snapd_go_do_compile_snap
 }
 
 do_install() {

--- a/recipes-support/snapd/snapd.inc
+++ b/recipes-support/snapd/snapd.inc
@@ -11,8 +11,6 @@ SRC_URI = "	\
 PACKAGECONFIG ??= "${@bb.utils.contains('DISTRO_FEATURES', 'apparmor', 'apparmor', '', d)}"
 PACKAGECONFIG[apparmor] = "--enable-apparmor,--disable-apparmor,apparmor,apparmor"
 
-GO_IMPORT = "github.com/snapcore/snapd"
-
 DEPENDS += " \
 	glib-2.0		\
 	libcap			\
@@ -35,15 +33,9 @@ EXTRA_OECONF += "			\
 	--with-snap-mount-dir=/snap \
 "
 
-inherit systemd autotools pkgconfig go
+inherit systemd autotools pkgconfig
 
-# disable shared runtime for x86
-# https://forum.snapcraft.io/t/yocto-rocko-core-snap-panic/3261
-# GO_DYNLINK is set with arch overrides in goarch.bbclass
-GO_DYNLINK:x86 = ""
-GO_DYNLINK:x86-64 = ""
-GO_DYNLINK:arm = ""
-GO_DYNLINK:aarch64 = ""
+require snapd-go.inc
 
 # Our tools build with autotools are inside the cmd subdirectory
 # and we need to tell the autotools class to look in there.
@@ -51,37 +43,18 @@ AUTOTOOLS_SCRIPT_PATH = "${S}/cmd"
 
 SYSTEMD_SERVICE:${PN} = "snapd.service"
 
-GO_BUILD_TAGS_snapd = "nosecboot"
-GO_BUILD_TAGS = "nosecboot nomanagers"
-
-# The go class does export a do_configure function, of which we need
-# to change the symlink set-up, to target snapd's environment.
 do_configure() {
-	mkdir -p ${S}/src/github.com/snapcore
-	ln -snf ${S} ${S}/src/${GO_IMPORT}
-	go_do_configure
-	# internally calls go run to generate some assets
-	(cd ${S} ; GOARCH=${GOHOSTARCH} sh -x ./mkversion.sh ${PV})
+	snapd_go_do_configure
 	autotools_do_configure
 }
 
 do_compile() {
-	(
-		cd ${S}
-		${GO} install -tags '${GO_BUILD_TAGS_snapd}' -mod=vendor ${GOBUILDFLAGS} github.com/snapcore/snapd/cmd/snapd
-		${GO} install -tags '${GO_BUILD_TAGS}' -mod=vendor ${GOBUILDFLAGS} github.com/snapcore/snapd/cmd/snap
-		${GO} install -tags '${GO_BUILD_TAGS}' -mod=vendor ${GOBUILDFLAGS} github.com/snapcore/snapd/cmd/snap-seccomp
-		${GO} install -tags '${GO_BUILD_TAGS}' -mod=vendor ${GOBUILDFLAGS} github.com/snapcore/snapd/cmd/snap-failure
-
-		# these *must* be built statically
-		for prog in snap-exec snap-update-ns snapctl; do
-			${GO} install -tags '${GO_BUILD_TAGS}' -mod=vendor -v \
-			      -ldflags="${GO_RPATH} -linkmode=external -extldflags '${HOST_CC_ARCH}${TOOLCHAIN_OPTIONS} ${GO_RPATH_LINK} ${LDFLAGS} -static'" \
-			      github.com/snapcore/snapd/cmd/$prog
-		done
-	)
+	snapd_go_do_compile
 	# build the rest
-	autotools_do_compile
+	(
+		cd ${B}
+		autotools_do_compile
+	)
 }
 
 do_install() {
@@ -114,14 +87,7 @@ do_install() {
 	   ${D}${systemd_unitdir}
 	rm -rf ${D}${prefix}${systemd_unitdir}
 
-	install -m 0755 ${B}/${GO_BUILD_BINDIR}/snapd ${D}${libdir}/snapd/
-	install -m 0755 ${B}/${GO_BUILD_BINDIR}/snap-exec ${D}${libdir}/snapd/
-	install -m 0755 ${B}/${GO_BUILD_BINDIR}/snap-seccomp ${D}${libdir}/snapd/
-	install -m 0755 ${B}/${GO_BUILD_BINDIR}/snap-update-ns ${D}${libdir}/snapd/
-	install -m 0755 ${B}/${GO_BUILD_BINDIR}/snapctl ${D}${libdir}/snapd/
-	install -m 0755 ${B}/${GO_BUILD_BINDIR}/snap-failure ${D}${libdir}/snapd/
-	install -m 0755 ${B}/${GO_BUILD_BINDIR}/snap ${D}${bindir}
-	ln -s ${libdir}/snapd/snapctl ${D}${bindir}/snapctl
+	snapd_go_install
 
 	echo "PATH=\$PATH:/snap/bin" > ${D}${sysconfdir}/profile.d/20-snap.sh
 


### PR DESCRIPTION
Snapd supports go.mod, hence it is time to move to go-mod class. While at it, extract the common Go setup into a separate include file.