### PR TITLE
snapd: add snapd.apparmor.service to systemd services when apparmor is enabled

### DIFF
--- a/recipes-support/snapd/snapd.inc
+++ b/recipes-support/snapd/snapd.inc
@@ -41,7 +41,9 @@ require snapd-go.inc
 # and we need to tell the autotools class to look in there.
 AUTOTOOLS_SCRIPT_PATH = "${S}/cmd"
 
-SYSTEMD_SERVICE:${PN} = "snapd.service"
+SYSTEMD_SERVICE:${PN} = "snapd.service \
+	${@bb.utils.contains('PACKAGECONFIG', 'apparmor', 'snapd.apparmor.service', '', d)} \
+"
 
 do_configure() {
 	snapd_go_do_configure


### PR DESCRIPTION
The snapd.apparmor.service was not being added to the SYSTEMD_SERVICE list, even when apparmor was enabled in PACKAGECONFIG. This caused the service to not be auto-enabled and thus the apparmor profiles would not be loaded at the boot time.

Signed-off-by: Maciej Borzecki <maciek@thing.com>