### PR TITLE
Pass -modcacherw when not using GOBUILDFLAGS

### DIFF
--- a/recipes-support/snapd/snapd-go.inc
+++ b/recipes-support/snapd/snapd-go.inc
@@ -47,6 +47,7 @@ snapd_go_do_compile() {
 			      -ldflags="${GO_RPATH} -linkmode=external -extldflags '${HOST_CC_ARCH}${TOOLCHAIN_OPTIONS} ${GO_RPATH_LINK} ${LDFLAGS} -static'" \
 			      -trimpath \
 			      -mod vendor \
+			      -modcacherw \
 			      github.com/snapcore/snapd/cmd/$prog
 		done
 	)


### PR DESCRIPTION
This fixes the issue where some of the cache would end up read-only and be annoying to work with.