### PR TITLE
Pass -mod=vendor instead of -mod vendor

### DIFF
--- a/recipes-support/snapd/snapd-go.inc
+++ b/recipes-support/snapd/snapd-go.inc
@@ -46,7 +46,7 @@ snapd_go_do_compile() {
 			${GO} install -tags '${GO_BUILD_TAGS}' -v \
 			      -ldflags="${GO_RPATH} -linkmode=external -extldflags '${HOST_CC_ARCH}${TOOLCHAIN_OPTIONS} ${GO_RPATH_LINK} ${LDFLAGS} -static'" \
 			      -trimpath \
-			      -mod vendor \
+			      -mod=vendor \
 			      github.com/snapcore/snapd/cmd/$prog
 		done
 	)


### PR DESCRIPTION
This ensures that the same syntax is used for all the invocations, making grepping easier to find all the occurrences.