### PR TITLE
linux-yocto: drop bbappend

### DIFF
--- a/recipes-kernel/linux/linux-yocto_5.15.bbappend
+++ b/recipes-kernel/linux/linux-yocto_5.15.bbappend
@@ -1,1 +1,0 @@
-require recipes-kernel/linux/linux-snapd.inc


### PR DESCRIPTION
Drop bbappend. The patches appear to apply cleanly to most kernels.