### PR TITLE
Do not hard-code -modcacherw, -mod=vendor

### DIFF
--- a/recipes-support/snapd/snapd-go.inc
+++ b/recipes-support/snapd/snapd-go.inc
@@ -46,8 +46,8 @@ snapd_go_do_compile() {
 			${GO} install -tags '${GO_BUILD_TAGS}' -v \
 			      -ldflags="${GO_RPATH} -linkmode=external -extldflags '${HOST_CC_ARCH}${TOOLCHAIN_OPTIONS} ${GO_RPATH_LINK} ${LDFLAGS} -static'" \
 			      -trimpath \
-			      -mod=vendor \
-			      -modcacherw \
+			      "${@bb.utils.contains('GOBUILDFLAGS', '-mod=vendor', '-mod=vendor', '', d)}" \
+			      "${@bb.utils.contains('GOBUILDFLAGS', '-modcacherw', '-modcacherw', '', d)}" \
 			      github.com/snapcore/snapd/cmd/$prog
 		done
 	)


### PR DESCRIPTION
Those options make sense _right now_ in _some_ configurations, but I think it is a mistake to hard-code them unconditionally. We cannot use $GOBUILDFLAGS directly, as some of the parts of snapd require careful linking configuration, but we _can_ selectively pass options from GOBUILDFLAGS to our otherwise hand-crafted argument list.