### PR TITLE
snapd: bump to 2.60

### DIFF
--- a/recipes-support/snapd/snapd-2.58.3.inc
+++ b/recipes-support/snapd/snapd-2.58.3.inc
@@ -1,6 +1,0 @@
-SRC_URI = "https://${GO_IMPORT}/releases/download/${PV}/snapd_${PV}.vendor.tar.xz"
-
-SRC_URI[md5sum] = "852110945dd61f22258ae1a80af55447"
-SRC_URI[sha256sum] = "7b8319b5ce1c2957651d0fec8c935bfbee02a1340927d9055ac1bdfdb9c1fca5"
-
-S = "${WORKDIR}/${PN}-${PV}"

--- a/recipes-support/snapd/snapd-2.60.inc
+++ b/recipes-support/snapd/snapd-2.60.inc
@@ -1,0 +1,6 @@
+SRC_URI = "https://${GO_IMPORT}/releases/download/${PV}/snapd_${PV}.vendor.tar.xz"
+
+SRC_URI[md5sum] = "bad2ff907110e0c095c1f245101a2968"
+SRC_URI[sha256sum] = "1d940ba7cee1b6a1fd961c591abf8fdde9d313eff0fb8b6967ad01f40426f33e"
+
+S = "${WORKDIR}/${PN}-${PV}"

--- a/recipes-support/snapd/snapd-git.inc
+++ b/recipes-support/snapd/snapd-git.inc
@@ -2,10 +2,10 @@ PR = "r0"
 
 SRC_URI = "git://github.com/snapcore/snapd.git;protocol=https;branch=release/2.58;destsuffix=git/"
 
-PV = "2.58.3+git${SRCPV}"
+PV = "2.60+git${SRCPV}"
 S = "${WORKDIR}/git"
 
-SRCREV = "6c067a778203ac0696084bf2b42bbf46ef35706a"
+SRCREV = "87725a5df4574605c6acc90a4dcedab87d760e6b"
 
 DEFAULT_PREFERENCE ??= "-1"
 

--- a/recipes-support/snapd/snapd-native_2.60.bb
+++ b/recipes-support/snapd/snapd-native_2.60.bb
@@ -9,8 +9,8 @@ SRC_URI = "									\
 	https://${GO_IMPORT}/releases/download/${PV}/snapd_${PV}.vendor.tar.xz	\
 "
 
-SRC_URI[md5sum] = "852110945dd61f22258ae1a80af55447"
-SRC_URI[sha256sum] = "7b8319b5ce1c2957651d0fec8c935bfbee02a1340927d9055ac1bdfdb9c1fca5"
+SRC_URI[md5sum] = "bad2ff907110e0c095c1f245101a2968"
+SRC_URI[sha256sum] = "1d940ba7cee1b6a1fd961c591abf8fdde9d313eff0fb8b6967ad01f40426f33e"
 
 RDEPENDS_${PN} += "		\
 	ca-certificates		\

--- a/recipes-support/snapd/snapd-native_2.60.bb
+++ b/recipes-support/snapd/snapd-native_2.60.bb
@@ -5,19 +5,13 @@ HOMEPAGE = "https://www.snapcraft.io"
 LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://${WORKDIR}/snapd-${PV}/COPYING;md5=d32239bcb673463ab874e80d47fae504"
 
-SRC_URI = "									\
-	https://${GO_IMPORT}/releases/download/${PV}/snapd_${PV}.vendor.tar.xz	\
-"
-
-SRC_URI[md5sum] = "bad2ff907110e0c095c1f245101a2968"
-SRC_URI[sha256sum] = "1d940ba7cee1b6a1fd961c591abf8fdde9d313eff0fb8b6967ad01f40426f33e"
+require snapd-2.60.inc
+S = "${WORKDIR}/snapd-${PV}"
 
 RDEPENDS_${PN} += "		\
 	ca-certificates		\
 	bash \
 "
-
-S = "${WORKDIR}/snapd-${PV}"
 
 require snapd-go.inc
 

--- a/recipes-support/snapd/snapd_2.58.3.bb
+++ b/recipes-support/snapd/snapd_2.58.3.bb
@@ -1,2 +1,0 @@
-include snapd.inc
-include snapd-2.58.3.inc

--- a/recipes-support/snapd/snapd_2.60.bb
+++ b/recipes-support/snapd/snapd_2.60.bb
@@ -1,0 +1,2 @@
+include snapd.inc
+include snapd-2.60.inc


### PR DESCRIPTION
I didn't notice that the snapd-native recipe was not converted along with the recent git-or-tarball patches. There's some duplication that could be removed to make it easier to maintain.