### PR TITLE
Pass -modcacherw to go mod vendor

### DIFF
--- a/recipes-support/snapd/snapd-go.inc
+++ b/recipes-support/snapd/snapd-go.inc
@@ -34,7 +34,7 @@ snapd_go_do_configure() {
 snapd_go_do_compile() {
 	(
 		cd ${S}
-		test -d vendor || ${GO} mod vendor
+		test -d vendor || ${GO} mod vendor "${@bb.utils.contains('GOBUILDFLAGS', '-modcacherw', '-modcacherw', '', d)}"
 		${GO} install -tags '${GO_BUILD_TAGS_snapd}' ${GOBUILDFLAGS} github.com/snapcore/snapd/cmd/snapd
 		${GO} install -tags '${GO_BUILD_TAGS}' ${GOBUILDFLAGS} github.com/snapcore/snapd/cmd/snap
 		${GO} install -tags '${GO_BUILD_TAGS}' ${GOBUILDFLAGS} github.com/snapcore/snapd/cmd/snap-seccomp


### PR DESCRIPTION
This fixes cache poisoning that otherwise occurs while building snapd from git.