### PR TITLE
Enable CI for riscv64

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -47,7 +47,7 @@ jobs:
           kas checkout ${{ matrix.kas }}
       - name: Run kas build
         run: |
-          kas build kas-poky-snapd.yml --target snapd-demo-image
+          kas build ${{ matrix.kas }} --target snapd-demo-image
       - name: Unmount tmpfs
         if: always()
         run: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,6 +10,7 @@ jobs:
         kas:
           - kas-poky-snapd.aarch64.yml
           - kas-poky-snapd.x86_64.yml
+          - kas-poky-snapd.riscv64.yml
     # TODO: use large runners when available
     runs-on: [self-hosted, Linux]
     timeout-minutes: 240

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,6 +10,7 @@ jobs:
         kas:
           - kas-poky-snapd.aarch64.yml
           - kas-poky-snapd.x86_64.yml
+          - kas-poky-snapd.riscv64.yml
     # TODO: use large runners when available
     runs-on: [self-hosted, Linux]
     timeout-minutes: 240

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -47,7 +47,7 @@ jobs:
           kas checkout ${{ matrix.kas }}
       - name: Run kas build
         run: |
-          kas build kas-poky-snapd.yml --target snapd-demo-image
+          kas build ${{ matrix.kas }} --target snapd-demo-image
       - uses: actions/upload-artifact@v4
         with:
           name: image-${{ matrix.kas }}

--- a/kas-poky-snapd.riscv64.yml
+++ b/kas-poky-snapd.riscv64.yml
@@ -1,0 +1,5 @@
+header:
+  version: 8
+  includes:
+    - kas-poky-snapd.common.yml
+machine: qemuriscv64


### PR DESCRIPTION
I've tested this locally and it works, boots and can install snaps.

There's not that many snaps that exist, even hello-world is not installable because hello-world depends on core which is not available on this architecture.