### PR TITLE
ci: add workflow with smoke-build with kas

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,54 @@
+name: Smoke build
+on:
+  pull_request:
+    branches: ["master", "kirkstone"]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        kas:
+          - kas-poky-snapd.aarch64.yml
+          - kas-poky-snapd.x86_64.yml
+    # TODO: use large runners when available
+    runs-on: [self-hosted, Linux]
+    timeout-minutes: 240
+    name: ${{ matrix.kas }}
+    env:
+      # On non-ephemeral workers, downloads and sstate is cached.
+      DL_DIR: /srv/meta-snapd/kirkstone/downloads
+      SSTATE_DIR: /srv/meta-snapd/kirkstone/sstate-cache
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo -E DEBIAN_FRONTEND=noninteractive apt install -y kas chrpath diffstat bzip2 cpp g++ gcc lz4 make rpcsvc-proto
+          kas --version
+      - name: Setup DL_DIR and SSTATE_DIR
+        run: |
+          sudo mkdir -p "$DL_DIR"
+          sudo mkdir -p "$SSTATE_DIR"
+          sudo chown $(id -u).$(id -g) "$DL_DIR" "$SSTATE_DIR"
+          # This hack makes DL_DIR and SSTATE_DIR overrides compatible with kas 2.6.3 in Ubuntu 22.04
+          mkdir -p build/conf
+          printf 'DL_DIR = "%s"\n' "$DL_DIR" >build/conf/auto.conf
+          printf 'SSTATE_DIR = "%s"\n' "$SSTATE_DIR" >> build/conf/auto.conf
+      - name: Use tmpfs for TMPDIR
+        run: |
+          mkdir -p build/tmp
+          if [ "$(LANG=C free --total --giga | awk -e '/Total/ { print $2 }')" -gt 64 ]; then
+            sudo mount -o size=64G -t tmpfs none build/tmp
+          fi
+      - name: Run kas checkout
+        run: |
+          kas checkout ${{ matrix.kas }}
+      - name: Run kas build
+        run: |
+          kas build ${{ matrix.kas }} --target snapd-demo-image
+      - name: Unmount tmpfs
+        if: always()
+        run: |
+          # Lazy umount as apparently something may be using this still?
+          sudo umount -l build/tmp || true

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,61 @@
+name: Reference build
+on:
+  push:
+    branches: ["master", "kirkstone"]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        kas:
+          - kas-poky-snapd.aarch64.yml
+          - kas-poky-snapd.x86_64.yml
+    # TODO: use large runners when available
+    runs-on: [self-hosted, Linux]
+    timeout-minutes: 240
+    name: ${{ matrix.kas }}
+    env:
+      # On non-ephemeral workers, downloads and sstate is cached.
+      DL_DIR: /srv/meta-snapd/kirkstone/downloads
+      SSTATE_DIR: /srv/meta-snapd/kirkstone/sstate-cache
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo -E DEBIAN_FRONTEND=noninteractive apt install -y kas chrpath diffstat bzip2 cpp g++ gcc lz4 make rpcsvc-proto
+          kas --version
+      - name: Setup DL_DIR and SSTATE_DIR
+        run: |
+          sudo mkdir -p "$DL_DIR"
+          sudo mkdir -p "$SSTATE_DIR"
+          sudo chown $(id -u).$(id -g) "$DL_DIR" "$SSTATE_DIR"
+          # This hack makes DL_DIR and SSTATE_DIR overrides compatible with kas 2.6.3 in Ubuntu 22.04
+          mkdir -p build/conf
+          printf 'DL_DIR = "%s"\n' "$DL_DIR" >build/conf/auto.conf
+          printf 'SSTATE_DIR = "%s"\n' "$SSTATE_DIR" >> build/conf/auto.conf
+      - name: Use tmpfs for TMPDIR
+        run: |
+          mkdir -p build/tmp
+          if [ "$(LANG=C free --total --giga | awk -e '/Total/ { print $2 }')" -gt 64 ]; then
+            sudo mount -o size=64G -t tmpfs none build/tmp
+          fi
+      - name: Run kas checkout
+        run: |
+          kas checkout ${{ matrix.kas }}
+      - name: Run kas build
+        run: |
+          kas build ${{ matrix.kas }} --target snapd-demo-image
+      - uses: actions/upload-artifact@v4
+        with:
+          name: image-${{ matrix.kas }}
+          path: build/tmp/deploy/images
+          if-no-files-found: warn
+          retention-days: 1
+          compression-level: 0
+      - name: Unmount tmpfs
+        if: always()
+        run: |
+          # Lazy umount as apparently something may be using this still?
+          sudo umount -l build/tmp || true

--- a/kas-poky-snapd.aarch64.yml
+++ b/kas-poky-snapd.aarch64.yml
@@ -1,0 +1,5 @@
+header:
+  version: 8
+  includes:
+    - kas-poky-snapd.common.yml
+machine: qemuarm64

--- a/kas-poky-snapd.common.yml
+++ b/kas-poky-snapd.common.yml
@@ -1,0 +1,77 @@
+header:
+  version: 8
+
+distro: poky
+target:
+  - snapd-demo-image
+
+repos:
+  meta-snapd:
+
+  poky:
+    url: https://git.yoctoproject.org/git/poky
+    path: layers/poky
+    refspec: kirkstone
+    layers:
+      meta:
+      meta-poky:
+      meta-yocto-bsp:
+
+  meta-openembedded:
+    url: http://git.openembedded.org/meta-openembedded
+    path: layers/meta-openembedded
+    refspec: kirkstone
+    layers:
+      meta-oe:
+      meta-python:
+      meta-networking:
+      meta-perl:
+      meta-filesystems:
+
+  meta-security:
+    url: http://git.yoctoproject.org/git/meta-security
+    path: layers/meta-security
+    refspec: kirkstone
+
+bblayers_conf_header:
+  standard: |
+    POKY_BBLAYERS_CONF_VERSION = "2"
+    BBPATH = "${TOPDIR}"
+    BBFILES ?= ""
+local_conf_header:
+  reduce_diskspace: |
+    INHERIT += "rm_work"
+    RM_WORK_EXCLUDE += "snapd"
+  standard: |
+    CONF_VERSION = "2"
+    PACKAGE_CLASSES = "package_ipk"
+    SDKMACHINE = "x86_64"
+    USER_CLASSES = "buildstats"
+    PATCHRESOLVE = "noop"
+  debug-tweaks: |
+    EXTRA_IMAGE_FEATURES = "debug-tweaks"
+  distro: |
+    DISTRO_FEATURES:append = " apparmor security usrmerge"
+  systemd: |
+    INIT_MANAGER = "systemd"
+    DISTRO_FEATURES:append = " systemd"
+  diskmon: |
+    BB_DISKMON_DIRS = "\
+        STOPTASKS,${TMPDIR},1G,100K \
+        STOPTASKS,${DL_DIR},1G,100K \
+        STOPTASKS,${SSTATE_DIR},1G,100K \
+        STOPTASKS,/tmp,100M,100K \
+        HALT,${TMPDIR},100M,1K \
+        HALT,${DL_DIR},100M,1K \
+        HALT,${SSTATE_DIR},100M,1K \
+        HALT,/tmp,10M,1K"
+  snapd: |
+    CORE_IMAGE_EXTRA_INSTALL += " \
+               packagegroup-snapd \
+               bash \
+               "
+  image-tweaks: |
+    # some room for installing snaps
+    IMAGE_ROOTFS_EXTRA_SPACE = "512000"
+    # snapd assumes root's home is /root
+    ROOT_HOME = "/root"

--- a/kas-poky-snapd.x86_64.yml
+++ b/kas-poky-snapd.x86_64.yml
@@ -1,0 +1,5 @@
+header:
+  version: 8
+  includes:
+    - kas-poky-snapd.common.yml
+machine: qemux86-64

--- a/recipes-support/snapd/snapd-2.61.2.inc
+++ b/recipes-support/snapd/snapd-2.61.2.inc
@@ -1,6 +1,0 @@
-SRC_URI = "https://${GO_IMPORT}/releases/download/${PV}/snapd_${PV}.vendor.tar.xz"
-
-SRC_URI[md5sum] = "06b54b66fc2090903f89548dae45351e"
-SRC_URI[sha256sum] = "d000725250a4d9c8a931b74df9733479a2851d03fe1e663a81fcb61b21509702"
-
-S = "${WORKDIR}/${PN}-${PV}"

--- a/recipes-support/snapd/snapd-2.61.3.inc
+++ b/recipes-support/snapd/snapd-2.61.3.inc
@@ -1,0 +1,6 @@
+SRC_URI = "https://${GO_IMPORT}/releases/download/${PV}/snapd_${PV}.vendor.tar.xz"
+
+SRC_URI[md5sum] = "407a07be765fc817c7030ce606e74944"
+SRC_URI[sha256sum] = "90d427ca0a0e1306e647c6091176fba678522e2af04228aa274a34d011c82123"
+
+S = "${WORKDIR}/${PN}-${PV}"

--- a/recipes-support/snapd/snapd-git.inc
+++ b/recipes-support/snapd/snapd-git.inc
@@ -1,12 +1,12 @@
 PR = "r0"
 
 
-BASEPV = "2.61.2"
+BASEPV = "2.61.3"
 SRC_URI = "git://github.com/snapcore/snapd.git;protocol=https;branch=release/${BASEPV};destsuffix=git/"
 PV = "${BASEPV}+git${SRCPV}"
 S = "${WORKDIR}/git"
 
-SRCREV = "a9c308a6cdb90b8d0e66b57d5f007b1a8bd7cdf1"
+SRCREV = "12e48ef9a63b92964a57e549107c648887b040eb"
 
 DEFAULT_PREFERENCE ??= "-1"
 

--- a/recipes-support/snapd/snapd-native_2.61.3.bb
+++ b/recipes-support/snapd/snapd-native_2.61.3.bb
@@ -5,7 +5,7 @@ HOMEPAGE = "https://www.snapcraft.io"
 LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://${WORKDIR}/snapd-${PV}/COPYING;md5=d32239bcb673463ab874e80d47fae504"
 
-require snapd-2.61.2.inc
+require snapd-2.61.3.inc
 S = "${WORKDIR}/snapd-${PV}"
 
 RDEPENDS_${PN} += "		\

--- a/recipes-support/snapd/snapd_2.61.2.bb
+++ b/recipes-support/snapd/snapd_2.61.2.bb
@@ -1,2 +1,0 @@
-include snapd.inc
-include snapd-2.61.2.inc

--- a/recipes-support/snapd/snapd_2.61.3.bb
+++ b/recipes-support/snapd/snapd_2.61.3.bb
@@ -1,0 +1,2 @@
+include snapd.inc
+include snapd-2.61.3.inc


### PR DESCRIPTION
The workflow is a straightforward kas build with worker-local state used as download and sstate-cache directories.